### PR TITLE
Fix blueprint condition selector

### DIFF
--- a/blueprints/auto_sun_blind.yaml
+++ b/blueprints/auto_sun_blind.yaml
@@ -185,7 +185,7 @@ blueprint:
       description: Extra conditions for the automation
       default: []
       selector:
-        action: {}
+        condition: {}
     action:
       name: Extra Actions
       description: Extra actions to run before intial service


### PR DESCRIPTION
The conditions section of the blueprint was requesting actions instead, so it was unusable. Now it properly requests conditions.